### PR TITLE
bug fix for launch_lammps_optimization_lj.py

### DIFF
--- a/aiida_lammps/calculations/lammps/__init__.py
+++ b/aiida_lammps/calculations/lammps/__init__.py
@@ -266,8 +266,9 @@ class BaseLammpsCalculation(JobCalculation):
             infile.write(structure_txt)
 
         potential_filename = tempfolder.get_abs_path(self._INPUT_POTENTIAL)
-        with open(potential_filename, 'w') as infile:
-            infile.write(potential_txt)
+        if potential_txt is not None:
+            with open(potential_filename, 'w') as infile:
+                infile.write(potential_txt)
 
         self._create_additional_files(tempfolder, inputdict)
 


### PR DESCRIPTION
- No need to write a potential file for LJ
- [LJ potential generation](https://github.com/abelcarreras/aiida-lammps/blob/master/aiida_lammps/calculations/lammps/potentials/lennard_jones.py#L4) returns `None`
- writing a potential file with `None` runs into an `AttributeError`